### PR TITLE
chore: update @lambdacurry/medusa-forms to version 0.2.6

### DIFF
--- a/packages/medusa-forms/package.json
+++ b/packages/medusa-forms/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@lambdacurry/medusa-forms",
-  "version": "0.2.4",
+  "version": "0.2.6",
   "type": "module",
-  "main": "./dist/cjs/index.js",
+  "main": "./dist/cjs/index.cjs",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "files": [
@@ -16,7 +16,7 @@
       },
       "require": {
         "types": "./dist/types/index.d.ts",
-        "default": "./dist/cjs/index.js"
+        "default": "./dist/cjs/index.cjs"
       }
     },
     "./controlled": {
@@ -26,7 +26,7 @@
       },
       "require": {
         "types": "./dist/types/controlled/index.d.ts",
-        "default": "./dist/cjs/controlled/index.js"
+        "default": "./dist/cjs/controlled/index.cjs"
       }
     },
     "./ui": {
@@ -36,7 +36,7 @@
       },
       "require": {
         "types": "./dist/types/ui/index.d.ts",
-        "default": "./dist/cjs/ui/index.js"
+        "default": "./dist/cjs/ui/index.cjs"
       }
     }
   },

--- a/packages/medusa-forms/vite.config.ts
+++ b/packages/medusa-forms/vite.config.ts
@@ -48,8 +48,8 @@ export default defineConfig({
         {
           format: 'cjs',
           dir: 'dist/cjs',
-          entryFileNames: '[name].js',
-          chunkFileNames: '[name].js',
+          entryFileNames: '[name].cjs',
+          chunkFileNames: '[name].cjs',
         },
       ],
       external: [


### PR DESCRIPTION
- Bump version from 0.2.4 to 0.2.6
- Update package.json to specify .cjs extension for CommonJS entry points
- Adjust vite.config.ts to output .cjs files for CommonJS format
- Add package-lock.json and update yarn.lock for dependency management

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal package configuration to use the `.cjs` extension for CommonJS build outputs.
  - Incremented package version to 0.2.6.

No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->