### PR TITLE
Fix: adjust spacing in RadioGroupItemField label for better a11y

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lambdacurry/forms",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/components/src/ui/radio-group-item-field.tsx
+++ b/packages/components/src/ui/radio-group-item-field.tsx
@@ -31,7 +31,7 @@ const RadioGroupItemField = ({
   const LabelComponent = components?.Label || Label;
 
   return (
-    <div className={cn('flex items-center space-x-2', wrapperClassName)}>
+    <div className={cn('flex items-center', wrapperClassName)}>
       <RadioGroupItemComponent
         className={cn(
           'h-4 w-4 rounded-full border border-primary text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
@@ -47,7 +47,7 @@ const RadioGroupItemField = ({
         <LabelComponent
           htmlFor={props.id}
           className={cn(
-            'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
+            'text-sm pl-2 font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
             labelClassName,
           )}
         >


### PR DESCRIPTION
As you can see in the image, adding margin to create space between the element and its label causes an issue: the user can’t click the label when the cursor is in that small gap between the two elements.

<img width="335" height="90" alt="image" src="https://github.com/user-attachments/assets/9f724612-44fc-42b5-87a5-32385b89bf3b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Adjusted radio item layout by removing the horizontal gap between item and label and adding left padding to the label for cleaner alignment and improved readability; no behavioral or accessibility changes.

- **Chores**
  - Bumped components package version (0.19.5 → 0.19.6).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->