### PR TITLE
fix: allow external onChange to override PhoneNumberInput's internal handler

### DIFF
--- a/packages/components/src/ui/phone-input.tsx
+++ b/packages/components/src/ui/phone-input.tsx
@@ -134,10 +134,10 @@ export const PhoneNumberInput = ({
       )}
       data-slot="input"
       aria-label={props['aria-label']}
-      {...props}
       value={display}
       onChange={handleInputChange}
       onKeyDown={handleKeyDown}
+      {...props}
     />
   );
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Phone Input now respects parent-provided value and event handlers, ensuring controlled usage works as expected.
  * Custom onChange/onKeyDown from consumers reliably override internal behavior, improving compatibility with form libraries and key handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->