### PR TITLE
Add clearSearchOnClose prop to Select component

### DIFF
--- a/packages/components/src/ui/select.tsx
+++ b/packages/components/src/ui/select.tsx
@@ -49,6 +49,8 @@ export interface SelectProps<T extends React.Key = string>
   // Search behavior
   searchable?: boolean;
   searchInputProps?: React.ComponentPropsWithoutRef<typeof CommandInput>;
+  // Clear the search input when the dropdown closes
+  clearSearchOnClose?: boolean;
   // Creatable behavior
   creatable?: boolean;
   onCreateOption?: (input: string) => SelectOption<T> | Promise<SelectOption<T>>;
@@ -74,6 +76,7 @@ export function Select<T extends React.Key = string>({
   components,
   searchable = true,
   searchInputProps,
+  clearSearchOnClose = false,
   creatable = false,
   onCreateOption,
   createOptionLabel,
@@ -95,6 +98,13 @@ export function Select<T extends React.Key = string>({
       if (selectedEl) selectedEl.scrollIntoView({ block: 'center' });
     });
   }, [popoverState.isOpen]);
+
+  // When closing, optionally clear the search query to reset the input value
+  useEffect(() => {
+    if (!popoverState.isOpen && clearSearchOnClose) {
+      setSearchQuery('');
+    }
+  }, [popoverState.isOpen, clearSearchOnClose]);
 
   const selectedOption = options.find((o) => o.value === value);
 


### PR DESCRIPTION
Add a `clearSearchOnClose` prop to the Select component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Select now supports an option to automatically clear the search input when the dropdown closes, reducing stale queries and improving repeat selections.
  * Backward compatible: the feature is disabled by default; enable it via a new component prop to opt in. No changes to current behavior unless explicitly activated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->