### PR TITLE
ci: update GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -30,10 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v5
         with:
           node-version: '22.9.0'
 

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -11,6 +11,7 @@ on:
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
+  issues: write
   pages: write
   id-token: write
   pull-requests: write
@@ -29,10 +30,10 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v5
         with:
           node-version: '22.9.0'
 
@@ -60,7 +61,8 @@ jobs:
 
       # Add a comment to the PR with the preview URL
       - name: Comment PR
-        uses: actions/github-script@v6
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/github-script@v8
         with:
           script: |
             const previewUrl = `https://lambda-curry.github.io/forms/pr-${context.issue.number}/`;
@@ -143,7 +145,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: gh-pages
           

--- a/.github/workflows/pr-quality-checks.yml
+++ b/.github/workflows/pr-quality-checks.yml
@@ -27,12 +27,12 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v5
         with:
           node-version: '22.9.0'
 
@@ -43,7 +43,7 @@ jobs:
         run: yarn install
 
       - name: Cache Turbo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-${{ github.ref_name }}-${{ hashFiles('**/yarn.lock') }}-${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v5
         with:
             node-version: '22.9.0'
   
@@ -44,4 +44,3 @@ jobs:
           name: test-failure
           path: packages/components/storybook-static
           retention-days: 2
-

--- a/packages/components/src/ui/checkbox-field.tsx
+++ b/packages/components/src/ui/checkbox-field.tsx
@@ -68,7 +68,11 @@ const CheckboxField = ({
 
         return (
           <FormItem
-            className={cn('flex flex-row gap-3 space-y-0', hasSupportingText ? 'items-start' : 'items-center', className)}
+            className={cn(
+              'flex flex-row gap-3 space-y-0',
+              hasSupportingText ? 'items-start' : 'items-center',
+              className,
+            )}
           >
             <FormControl Component={components?.FormControl}>
               <CheckboxComponent


### PR DESCRIPTION
## Summary

- Update GitHub-maintained actions to Node 24-compatible major versions.
- Grant `issues: write` for preview comments on trusted same-repository PRs.
- Skip the preview comment step for fork PRs, where GitHub downgrades `GITHUB_TOKEN` permissions to read-only.

## Why

The failing preview run is not caused by the project Node version. The build succeeds, then `actions/github-script@v6` receives a 403 when trying to create a comment on fork PR #183. The Node 20 messages are action-runtime deprecation warnings.

## Validation

- `git diff --check`
- Workflow changes reviewed against the failed run: <https://github.com/lambda-curry/forms/actions/runs/30287010916>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated build, test, release, deployment, and preview workflows to use newer setup and caching actions.
  - Improved pull request preview comment update permissions.
  - Preserved existing runtime versions, commands, triggers, and deployment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->