### PR TITLE
ci: allow Changesets release PR creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 permissions:
   id-token: write # Required for OIDC trusted publishing
   contents: write # Required for pushing git tags after publishing
+  pull-requests: write # Required for Changesets to create the release PR
 
 jobs:
   release:


### PR DESCRIPTION
Add pull-requests write permission required by changesets/action to create the release PR after merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation permissions to support creating or modifying release pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->