### PR TITLE
fix: keep docs workspace private

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lambdacurry/forms-docs",
   "version": "0.2.0",
+  "private": true,
   "scripts": {
     "dev": "storybook dev -p 6006",
     "build": "storybook build",


### PR DESCRIPTION
Mark the Storybook docs workspace private so Changesets does not attempt to publish its already-existing 0.2.0 package during component releases.