### PR TITLE
fix: compare exact npm release versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint": "biome check .",
     "lint:fix": "biome check . --write",
     "prerelease": "turbo run build",
-    "release": "changeset publish",
+    "release": "node scripts/release-if-needed.mjs",
     "build-storybook": "turbo run build-storybook"
   },
   "devDependencies": {

--- a/scripts/release-if-needed.mjs
+++ b/scripts/release-if-needed.mjs
@@ -1,0 +1,28 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const publishablePackages = ["packages/components/package.json"];
+
+const unpublishedPackages = publishablePackages.filter((packagePath) => {
+  const localPackage = JSON.parse(readFileSync(packagePath, "utf8"));
+
+  try {
+    const publishedVersion = JSON.parse(
+      execFileSync("npm", ["view", localPackage.name, "version", "--json"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      }),
+    );
+
+    return publishedVersion !== localPackage.version;
+  } catch {
+    return true;
+  }
+});
+
+if (unpublishedPackages.length === 0) {
+  console.log("All publishable package versions are already on npm.");
+  process.exit(0);
+}
+
+execFileSync("yarn", ["changeset", "publish"], { stdio: "inherit" });

--- a/scripts/release-if-needed.mjs
+++ b/scripts/release-if-needed.mjs
@@ -7,14 +7,13 @@ const unpublishedPackages = publishablePackages.filter((packagePath) => {
   const localPackage = JSON.parse(readFileSync(packagePath, "utf8"));
 
   try {
-    const publishedVersion = JSON.parse(
-      execFileSync("npm", ["view", localPackage.name, "version", "--json"], {
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "pipe"],
-      }),
-    );
+    const exactVersion = execFileSync(
+      "npm",
+      ["view", `${localPackage.name}@${localPackage.version}`, "version"],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+    ).trim();
 
-    return publishedVersion !== localPackage.version;
+    return exactVersion !== localPackage.version;
   } catch {
     return true;
   }


### PR DESCRIPTION
Follow-up to #188: query the exact package version on npm using plain text so the release guard works under GitHub Actions' temporary npm config.